### PR TITLE
Fixed message in log from py2 scripts

### DIFF
--- a/assemblyline_v4_p2compat/common/logformat.py
+++ b/assemblyline_v4_p2compat/common/logformat.py
@@ -27,4 +27,4 @@ AL_JSON_FORMAT = '{{' \
     '"log.level": "%(levelname)s", ' \
     '"log.logger": "%(name)s", ' \
     '"process.pid": "%(process)d", ' \
-    '"message": %(message)s}}'.format(ip=ip, hostname=hostname)
+    '"message": "%(message)s"}}'.format(ip=ip, hostname=hostname)


### PR DESCRIPTION
Relating to [Crashes during vipermonkey py2 code do not reach logs server correctly](https://cccs.atlassian.net/browse/AL-196)
Problem not exclusive to when it crashes, normal messages (info) didn't get logged as well.

The error stems from the message not being encapsulated in quotes which might've been breaking the JSON format for the logs when inserting into elastic (so the entire JSON becomes the message) and why it doesn't show up as part of the viper event dataset.

![image](https://user-images.githubusercontent.com/62077998/92602481-3064cb80-f27c-11ea-80aa-e32ad7437bf2.png)
